### PR TITLE
Facebook Graph API-Version auswählbar machen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -63,6 +63,7 @@ yfeed_facebook_profile_id = User ID oder Page ID
 yfeed_facebook_token = Access Token
 yfeed_facebook_token_note = Optional (erforderlich für nicht allgemein öffentliche Einträge)
 yfeed_facebook_count = Anzahl der Einträge
+yfeed_facebook_api_version = API-Version
 yfeed_facebook_result_type = Ergebnis
 yfeed_facebook_result_type_feed = Alle Einträge
 yfeed_facebook_result_type_posts = Nur eigene Einträge

--- a/lib/stream/facebook_feed.php
+++ b/lib/stream/facebook_feed.php
@@ -49,6 +49,13 @@ class rex_yfeed_stream_facebook_feed extends rex_yfeed_stream_abstract
                 'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100],
                 'default' => 10,
             ],
+            [
+                'label' => rex_i18n::msg('yfeed_facebook_api_version'),
+                'name' => 'api_version',
+                'type' => 'select',
+                'options' => ["v3.2" => "3.2", "v3.1" => "3.1", "v3.0" => "3.0", "v2.12" => "2.12"],
+                'default' => "v3.2",
+            ],
         ];
     }
 
@@ -114,7 +121,7 @@ class rex_yfeed_stream_facebook_feed extends rex_yfeed_stream_abstract
             $credentials = [
                 'app_id' => rex_config::get('yfeed', 'facebook_app_id'),
                 'app_secret' => rex_config::get('yfeed', 'facebook_app_secret'),
-                'default_graph_version' => 'v2.6',
+                'default_graph_version' => $this->typeParams['api_version'],
             ];
             $facebook = new Facebook\Facebook($credentials);
             if ($this->typeParams['token']) {


### PR DESCRIPTION
closes #63 auf unbestimmte Zeit

https://developers.facebook.com/docs/graph-api/changelog/version2.12#mapi
Veröffentlicht 30. Januar 2018 | Verfügbar bis 1. Mai 2020

https://developers.facebook.com/docs/graph-api/changelog/version3.2
Released October 23, 2018 | Available until TBD
